### PR TITLE
Documentation feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ build/
 _yardoc
 doc/
 .idea/
+
+
+*.sublime-workspace
+*.sublime-project

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -18,9 +18,9 @@ fetch('https://happyscribe.co/api/v1/', {
 
 > Make sure to replace `**your_api_key_here**` with your API key.
 
-HappyScribe uses API keys to allow access to the API. You can register a new API key by logging in and going to [settings](https://www.happyscribe.co/users/edit) 
+HappyScribe uses API keys to allow access to the API. You can get your API key by logging in and going to [settings](https://www.happyscribe.co/users/edit) 
 
-HappyScribe expects for the API key to be included in all API requests to the server in a header that looks like the following:
+HappyScribe expects the API key to be included in all API requests to the server in a header that looks like the following:
 
 `Authorization: Bearer **your_api_key_here**"`
 

--- a/source/includes/_transcriptions.md
+++ b/source/includes/_transcriptions.md
@@ -1,6 +1,6 @@
 # Transcriptions
 
-## Get All Transcriptions
+## List All Transcriptions
 
 ```shell
 curl "https://happyscribe.co/api/v1/transcriptions" \
@@ -21,7 +21,7 @@ fetch('https://happyscribe.co/api/v1/transcriptions', {
 {
     "results": [
         {
-            "id": "e458099e7f8da149625854b5a7b6a026917ad306",
+            "id": "e458099e7f8da14f9625854ba7b6a026917ad306",
             "name": "interview1.mov",
             "createdAt": "2018-10-29T14:31:29.799Z",
             "updatedAt": "2018-10-29T14:31:38.495Z",
@@ -30,12 +30,12 @@ fetch('https://happyscribe.co/api/v1/transcriptions', {
             "language": "en-GB",
             "_links": {
               "self": {
-                "url": "http://localhost:3000/api/v1/transcriptions/e458099e7f8da149625854b5a7b6a026917ad306"
+                "url": "https://happyscribe.co/api/v1/transcriptions/e458099e7f8da14f9625854ba7b6a026917ad306"
               }
             }
         },
         {
-            "id": "9josdjdfo09j309omsldknslkjndfjknsdfs",
+            "id": "9jossdjdf09j309omsldknslkjndfjknsdfs",
             "name": "interview2.mov",
             "createdAt": "2018-10-29T14:31:29.799Z",
             "updatedAt": "2018-10-29T14:31:38.495Z",
@@ -44,10 +44,11 @@ fetch('https://happyscribe.co/api/v1/transcriptions', {
             "language": "en-GB",
             "_links": {
               "self": {
-                "url": "http://localhost:3000/api/v1/transcriptions/9josdjdfo09j309omsldknslkjndfjknsdfs"
+                "url": "https://happyscribe.co/api/v1/transcriptions/9jossdjdf09j309omsldknslkjndfjknsdfs"
               }
             }
         },
+        ...
     ],
     "total": 10,
     "_links": {
@@ -59,7 +60,7 @@ fetch('https://happyscribe.co/api/v1/transcriptions', {
         
 ```
 
-This endpoint retrieves your transcriptions.
+Returns a list of transcriptions you’ve previously created. The transcriptions are returned in sorted order, with the most recent charges appearing first. The information returned is metadata about each transcription, not the actual transcript. To retrieve a specific transcript you have to use the [export endpoint](#export-a-transcription).
 
 ### HTTP Request
 
@@ -75,7 +76,7 @@ page | 0 | Request a specific page
 Remember — a happy scribe is an authenticated scribe!
 </aside>
 
-## Create a New Transcription
+## Create a Transcription
 
 ```shell
 curl -X POST "https://happyscribe.co/api/v1/transcriptions" \
@@ -121,13 +122,13 @@ fetch('https://happyscribe.co/api/v1/transcriptions', {
   "language": "en-GB",
   "_links": {
     "self": {
-      "url": "http://localhost:3000/api/v1/transcriptions/f6511f81156114aede28dc85325a796ae7996d11"
+      "url": "https://happyscribe.co/api/v1/transcriptions/f6511f81s5611daede28dc85f25a796ae7996d11"
     },
   }
 }
 ```
 
-This endpoint creates a new transcription.
+This endpoint creates a new transcription. After a transcription is created, the system will proceed to automatically transcribe it. You can watch if the transcription process has finished by [retrieving a transcription](#retrieve-a-transcription).
 
 ### HTTP Request
 
@@ -139,18 +140,18 @@ Parameter | Type | Description
 --------- | ------ | -----------
 name | String | (required) Name of the transcription
 language | String | (required) [BCP-47](https://tools.ietf.org/html/bcp47) language code. Full list [here](/#languages)
-tmp_url | String | (required) A url where the media file is located and can be copied to our server.
+tmp_url | String | (required) A url where the media file is located and can be retrieved by our server.
 
 <aside class="notice">
-The media file <code>tmp_url</code> must be publicly acessible during the ingestion process, otherwise our server won't be able to make a copy of it.<br/>
+The media file <code>tmp_url</code> must be publicly accessible during the ingestion process, otherwise our server won't be able to make a copy of it.<br/>
 Once the file is copied and ingested, we no longer need access to the <code>tmp_url</code> and the file can be safely deleted.
 </aside>
 
 <aside class="success">
-For uploading files directly to our sever, please see the section titled <a href="/#uploads">Uploads</a>
+Before creating a transcription, your media file has to be uploaded. Refer to the <a href="/#uploads">uploads section</a> for uploading files directly to our server and other options.
 </aside>
 
-## Get a Specific Transcription
+## Retrieve a Transcription
 
 ```shell
 curl "https://happyscribe.co/api/v1/transcriptions/<ID>" \
@@ -178,19 +179,19 @@ fetch('https://happyscribe.co/api/v1/transcriptions/<ID>', {
   "language": "en-GB",
   "_links": {
     "self": {
-      "url": "http://localhost:3000/api/v1/transcriptions/f6511f81156114aede28dc85325a796ae7996d11"
+      "url": "https://happyscribe.co/api/v1/transcriptions/f6511f81156114aede28dc85325a796ae7996d11"
     },
     "editor": {
       "url": "https://happyscribe.co/transcriptions/9josdjdfo09j309omsldknslkjndfjknsdfs/edit_v2",
     },
     "export": {  
-      "url": "http://localhost:3000/api/v1/transcriptions/f6511f81156114aede28dc85325a796ae7996d11/exports/new"
+      "url": "https://happyscribe.co/api/v1/transcriptions/f6511f81156114aede28dc85325a796ae7996d11/exports/new"
     },
   }
 }
 ```
 
-This endpoint retrieves a specific transcription.
+This endpoint retrieves information about a specific transcription. To retrieve the transcript you have to use the [export endpoint](#export-a-transcription).
 
 ### HTTP Request
 
@@ -202,13 +203,13 @@ Value | Description
 ----- | ---------- 
 `ingesting` | Media file is being ingested
 `automatic_transcribing` | Audio is being transcribed to text
-`automatic_done` | Transcription is finished
+`automatic_done` | Transcription is finished and ready to export!
 `aligning` | Text is being realigned with the audio
-`locked` | Transcription is locked due to insuffient credits
+`locked` | Transcription is locked due to insufficient credits
 `failed` | File failed to process
 `demo` | The initial demo file
 
-## Get a Transcription Export
+## Export a Transcription
 
 ```shell
 curl "https://happyscribe.co/api/v1/transcriptions/<ID>/export/new?format=txt" \
@@ -227,6 +228,10 @@ fetch('https://happyscribe.co/api/v1/transcriptions/<ID>/export/new?format=txt',
 
 This endpoint generates a transcription export.
 Exports are sent to the client as binary data. You'll need to capture the output and save it to your local filesystem.
+
+<aside class="notice">
+To export a transcription it must have the <code>state</code> = <code>automatic_done</code>. You can check the state by <a href="#retrieve-a-transcription">retrieving the transcription metadata</a>.
+</aside>
 
 ### HTTP Request
 

--- a/source/includes/_uploads.md
+++ b/source/includes/_uploads.md
@@ -1,20 +1,20 @@
 # Uploads
 
-When creating a transcript, a media file URL (accessible to our servers) must be provided.  
+When creating a transcription, a media file URL (accessible to our servers) must be provided.  
 This can be a publicly accessible URL hosted by yourselves or a third-party.  
-Alternatively, you can upload files directly to our S3 bucket and create the transcription using the returned URL.  
+Alternatively, you can upload files directly to our storage system (AWS S3 bucket) and create the transcription using the returned URL.  
 
 To upload files to our AWS S3 bucket, you must first request a signed URL using the endpoints below.  
 Once you have the signed URL, you can upload files as you would to any AWS S3 bucket.  
 
 We provide two types of signed URLs:
 
-- URL for PUTing files as a binary data type
-- URL for POSTing files as multipart form-data
+- Signed URL for PUTing files as a binary data type
+- Signed URL for POSTing files as multipart form-data
 
-Depending which type of upload you require, you should request a signed URL from one of these two endpoints:
+Depending on which type of upload you require, you should request a signed URL from one of these two endpoints:
 
-## Uploading Media Files
+## Binary Data File Upload
 
 ```shell
 curl "https://happyscribe.co/api/v1/uploads/new?filename=my_media.mp3" \
@@ -41,7 +41,7 @@ fetch('https://happyscribe.co/api/v1/uploads/new?filename=my_media.mp3', {
 This endpoint returns a signed URL which can be used to make PUT requests to our S3 bucket.  
 More information here: [https://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html)  
 
-Once the file is uploaded, this same url should be used as the `tmp_url` when creating the associated transcription.
+Once the file is uploaded, this same url should be used as the `tmp_url` when [creating the associated transcription.](#create-a-new-transcription)
 
 ### HTTP Request
 
@@ -86,7 +86,7 @@ This endpoint returns a URL and form fields which can be used to POST multipart 
 More information here: [https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html)
 
 Once the file is uploaded, S3 will respond with a URL in the XML body, as well as in the headers.  
-You should use this URL as the `tmp_url` when creating the associated transcription.  
+You should use this URL as the `tmp_url` when [creating the associated transcription.](#create-a-new-transcription)  
 
 ### HTTP Request
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -28,7 +28,7 @@ You can also access existing transcriptions and export them to various formats.
 
 We try to be a RESTfull API, using appropriate resource names and verbs.  
 Our API is versioned where breaking changes are released as incremental versions.  
-We'll try our best not to relase versions too often, and to reasonably support legacy versions ✌️.
+We'll try our best not to release versions too often, and to reasonably support legacy versions ✌️.
 
 If you have any questions, please write to us at [dev@happyscribe.co](mailto:dev@happyscribe.co). We'd love to hear from you 🙈
 


### PR DESCRIPTION
- For the transcriptions endpoint, slightly change the endpoint titles
   to make them more readable, with inspiration by the Stripe API docs
   https://stripe.com/docs/api/charges


<img width="185" alt="screen shot 2019-02-16 at 10 11 50" src="https://user-images.githubusercontent.com/15634635/52897319-5676d680-31d3-11e9-839e-7f2c3e1dcc9b.png">
<img width="225" alt="screen shot 2019-02-16 at 10 11 55" src="https://user-images.githubusercontent.com/15634635/52897321-5a0a5d80-31d3-11e9-9cae-515c50981f99.png">


- Review the code snippets
    - Change references from localhost to happyscribe.co
    - Make sure that hashed_ids that do not correspond to transcriptions

- General changes on the text to try to make it more friendly for someone
   new. And trying to anticipate caveats that users might find (i.e.
   when creating a transcription, making sure the user understands that
   first he has to have uploaded the file.)

- Grammar check with Grammarly

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->